### PR TITLE
Pin dependency versions and document installation

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,13 @@
 
 ## 설치 및 실행 방법
 
-### 1. 환경 변수 설정
+### 1. 의존성 설치
+아래 명령어로 프로젝트에서 필요한 패키지를 설치합니다.
+```bash
+pip install -r requirements.txt
+```
+
+### 2. 환경 변수 설정
 프로젝트를 실행하기 전에 아래 환경변수를 설정합니다. 이는 Azure OpenAI API 키 및 배포 ID를 포함합니다.
 
 - `AOAI_ENDPOINT`: Azure OpenAI API의 엔드포인트

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,5 +4,5 @@ langchain-core==0.3.41
 langchain-openai==0.3.7
 langgraph==0.3.5
 langsmith==0.3.11
-requests
-typing_extensions
+requests==2.32.4
+typing_extensions==4.13.2


### PR DESCRIPTION
## Summary
- pin `requests` and `typing_extensions` versions
- document how to install dependencies via `pip`

## Testing
- `python -m py_compile main.py`

------
https://chatgpt.com/codex/tasks/task_e_684e66f768f4832da55df70da485c0ca